### PR TITLE
add support for files that dont have command lines

### DIFF
--- a/json2cmake/__init__.py
+++ b/json2cmake/__init__.py
@@ -19,7 +19,8 @@ def freeze(obj):
 
 
 def parsecommand(command, directory=os.curdir):
-    command = shlex.split(command)
+    if (isinstance(command, basestring)):
+        command = shlex.split(command)
     words = iter(command)
     next(words)  # remove the initial 'cc' / 'c++'
 
@@ -67,8 +68,14 @@ class CompilationDatabase(object):
     def read(self, input):
         database = json.load(input)
         for entry in database:
-            command = freeze(
-                parsecommand(entry['command'], directory=entry['directory']))
+            if 'command' in entry.keys():
+                command = freeze(
+                    parsecommand(
+                        entry['command'], directory=entry['directory']))
+            if 'arguments' in entry.keys():
+                command = freeze(
+                    parsecommand(
+                        entry['arguments'], directory=entry['directory']))
             self.targets.setdefault(command, set()).add(entry['file'])
 
     def write(self, output, directory=None):


### PR DESCRIPTION
Tools like https://github.com/rizsotto/Bear produce compile_commands.json files which do not have 'command' strings they instead have an 'arguments' array.
This change allows json2cmake to accept these files without issues. An example of a compile_commands.json with this change can be found here https://gist.github.com/jfmherokiller/c4f7b288bbf44a464098ef7978815869