### PR TITLE
Add Travis build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+  - "2.7"
+install: pip install .
+script: true # TODO write and run some tests


### PR DESCRIPTION
This ensures that json2cmake can be installed, but not yet run.