### PR TITLE
Support -arch and -include

### DIFF
--- a/json2cmake/__init__.py
+++ b/json2cmake/__init__.py
@@ -60,6 +60,9 @@ def parsecommand(command, resolvepath):
             defines.append(word[2:])
         elif word == '-c':
             continue
+        elif word in ['-arch', '-include']:
+            options.append(word)
+            options.append(next(words))
         elif word.startswith('-'):
             options.append(word)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='json2cmake',
-    version='0.6.1',
+    version='0.6.2',
     description='Generate CMakeLists.txt from a compile_commands.json',
     long_description=long_description,
     url='https://github.com/AbigailBuccaneer/json2cmake',


### PR DESCRIPTION
These options both take an argument after them, which we don't currently support.

Fixes #26.