### PR TITLE
Handle -i{system,quote} without space before path

### DIFF
--- a/json2cmake/__init__.py
+++ b/json2cmake/__init__.py
@@ -26,6 +26,9 @@ def freeze(obj):
 
 
 def parsecommand(command, resolvepath):
+    ISYSTEM = '-isystem'
+    IQUOTE = '-iquote'
+
     if (isinstance(command, basestring)):
         command = shlex.split(command)
     words = iter(command)
@@ -44,14 +47,20 @@ def parsecommand(command, resolvepath):
         elif word.startswith('-I'):
             include = word[2:]
             includes.append(resolvepath(include))
-        elif word == '-isystem':
-            include = next(words)
+        elif word.startswith(ISYSTEM):
+            if word == ISYSTEM:
+                include = next(words)
+            else:
+                include = word[len(ISYSTEM):]
             include = resolvepath(include)
             if include not in includes:
                 includes.append(include)
             system_includes.add(include)
-        elif word == '-iquote':
-            include = next(words)
+        elif word.startswith(IQUOTE):
+            if word == IQUOTE:
+                include = next(words)
+            else:
+                include = word[len(IQUOTE):]
             include = resolvepath(include)
             if include not in includes:
                 includes.append(include)


### PR DESCRIPTION
* Although manual doesn't specify this it is allowed
  to pass -isystem or -iquote like this: -isystem/opt/lib
* If space is present before path, keep the current logic.
* Simple test (checked with gcc 9.1.0 and 5.3.0):

  mkdir -p /tmp/lib
  touch /tmp/lib/inc.h

  cat <<EOF > test.c
  #include "inc.h"

  int main(void)
  {
    return 0;
  }
  EOF

  gcc -isystem/tmp/lib test.c -o test